### PR TITLE
✨ chore: update Python version requirement and dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,20 +3,16 @@ name = "cube_dbt"
 dynamic = ["version"]
 description = "dbt integration for Cube"
 authors = [
-    {name = "Artyom Keydunov", email = "artyom@cube.dev"},
-    {name = "Igor Lukanin", email = "igor@cube.dev"},
+    { name = "Artyom Keydunov", email = "artyom@cube.dev" },
+    { name = "Igor Lukanin", email = "igor@cube.dev" },
 ]
-dependencies = [
-    "PyYAML>=6.0.1",
-]
-requires-python = ">=3.8"
+dependencies = ["PyYAML>=6.0.1"]
+requires-python = ">=3.10,<3.12"
 readme = "README.md"
-license = {text = "MIT"}
+license = { text = "MIT" }
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.4.2",
-]
+[dependency-groups]
+dev = ["pytest", "ruff"]
 
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning"]

--- a/src/cube_dbt/__init__.py
+++ b/src/cube_dbt/__init__.py
@@ -1,3 +1,5 @@
 from .column import Column
 from .dbt import Dbt
 from .model import Model
+
+__all__ = ["Column", "Dbt", "Model"]

--- a/src/cube_dbt/column.py
+++ b/src/cube_dbt/column.py
@@ -6,270 +6,252 @@ from cube_dbt.dump import dump
 # https://cube.dev/docs/reference/data-model/types-and-formats#dimension-types
 # are: time, string, number, boolean, and geo
 VALID_DIMENSION_TYPES = [
-  "boolean",
-  "geo",
-  "number",
-  "string",
-  "time",
+    "boolean",
+    "geo",
+    "number",
+    "string",
+    "time",
 ]
 # Other System's Type => Cube Type
 # See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
 BIGQUERY_TYPE_MAPPINGS = {
-  "array": "string",
-  "bool": "boolean",
-  "bytes": "string",
-  "date": "time",
-  "datetime": "time",
-  "geography": "geo",
-  "interval": "string",
-  "json": "string",
-
-  # numeric types
-  "int64": "number",
-  "int": "number",
-  "smallint": "number",
-  "integer": "number",
-  "bigint": "number",
-  "tinyint": "number",
-  "byteint": "number",
-  "numeric": "number",
-  "decimal": "number",
-  "bignumeric": "number",
-  "bigdecimal": "number",
-  "float64": "number",
-
-  "range": "string",
-  # string does not need to be mapped
-  "struct": "string",
-  # time does not need to be mapped
-  "timestamp": "time",
+    "array": "string",
+    "bool": "boolean",
+    "bytes": "string",
+    "date": "time",
+    "datetime": "time",
+    "geography": "geo",
+    "interval": "string",
+    "json": "string",
+    # numeric types
+    "int64": "number",
+    "int": "number",
+    "smallint": "number",
+    "integer": "number",
+    "bigint": "number",
+    "tinyint": "number",
+    "byteint": "number",
+    "numeric": "number",
+    "decimal": "number",
+    "bignumeric": "number",
+    "bigdecimal": "number",
+    "float64": "number",
+    "range": "string",
+    # string does not need to be mapped
+    "struct": "string",
+    # time does not need to be mapped
+    "timestamp": "time",
 }
 # See https://docs.snowflake.com/en/sql-reference-data-types
 SNOWFLAKE_TYPE_MAPPINGS = {
-  # Numeric data types
-  # number does not need to be mapped
-  "decimal": "number",
-  "dec": "number",
-  "numeric": "number",
-  "int": "number",
-  "integer": "number",
-  "bigint": "number",
-  "smallint": "number",
-  "tinyint": "number",
-  "byteint": "number",
-  "float": "number",
-  "float4": "number",
-  "float8": "number",
-  "double": "number",
-  "double precision": "number",
-  "real": "number",
-
-  # String & binary data types
-  "varchar": "string",
-  "char": "string",
-  "character": "string",
-  "nchar": "string",
-  # string does not need to be mapped
-  "text": "string",
-  "nvarchar": "string",
-  "nvarchar2": "string",
-  "char varying": "string",
-  "nchar varying": "string",
-  "binary": "string",
-  "varbinary": "string",
-
-  # Logical data types
-  # boolean does not need to be mapped
-
-  # Date & time data types
-  "date": "time",
-  "datetime": "time",
-  # time does not need to be mapped
-  "timestamp": "time",
-  "timestamp_ltz": "time",
-  "timestamp_ntz": "time",
-  "timestamp_tz": "time",
-
-  # Semi-structured data types
-  "variant": "string",
-  "object": "string",
-  "array": "string",
-
-  # Geospatial data types
-  "geography": "geo",
-  "geometry": "string",
-
-  # Vector data types
-  "vector": "string",
+    # Numeric data types
+    # number does not need to be mapped
+    "decimal": "number",
+    "dec": "number",
+    "numeric": "number",
+    "int": "number",
+    "integer": "number",
+    "bigint": "number",
+    "smallint": "number",
+    "tinyint": "number",
+    "byteint": "number",
+    "float": "number",
+    "float4": "number",
+    "float8": "number",
+    "double": "number",
+    "double precision": "number",
+    "real": "number",
+    # String & binary data types
+    "varchar": "string",
+    "char": "string",
+    "character": "string",
+    "nchar": "string",
+    # string does not need to be mapped
+    "text": "string",
+    "nvarchar": "string",
+    "nvarchar2": "string",
+    "char varying": "string",
+    "nchar varying": "string",
+    "binary": "string",
+    "varbinary": "string",
+    # Logical data types
+    # boolean does not need to be mapped
+    # Date & time data types
+    "date": "time",
+    "datetime": "time",
+    # time does not need to be mapped
+    "timestamp": "time",
+    "timestamp_ltz": "time",
+    "timestamp_ntz": "time",
+    "timestamp_tz": "time",
+    # Semi-structured data types
+    "variant": "string",
+    "object": "string",
+    "array": "string",
+    # Geospatial data types
+    "geography": "geo",
+    "geometry": "string",
+    # Vector data types
+    "vector": "string",
 }
 # See https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
 REDSHIFT_TYPE_MAPPINGS = {
-  # Signed two-byte integer
-  "smallint": "number",
-  "int2": "number",
-
-  # Signed four-byte integer
-  "integer": "number",
-  "int": "number",
-  "int4": "number",
-
-  # Signed eight-byte integer
-  "bigint": "number",
-  "int8": "number",
-
-  # Exact numeric of selectable precision
-  "decimal": "number",
-  "numeric": "number",
-
-  # Single precision floating-point number
-  "real": "number",
-  "float4": "number",
-
-  # Double precision floating-point number
-  "double precision": "number",
-  "float8": "number",
-  "float": "number",
-
-  # Fixed-length character string
-  "char": "string",
-  "character": "string",
-  "nchar": "string",
-  "bpchar": "string",
-
-  # Variable-length character string with a user-defined limit
-  "varchar": "string",
-  "character varying": "string",
-  "nvarchar": "string",
-  "text": "string",
-
-  # Calendar date (year, month, day)
-  "date": "time",
-
-  # Time of day
-  "time": "time",
-  "time without time zone": "time",
-
-  # Time of day with time zone
-  "timetz": "time",
-  "time with time zone": "time",
-
-  # Date and time (without time zone)
-  "timestamp": "time",
-  "timestamp without time zone": "time",
-
-  # Date and time (with time zone)
-  "timestamptz": "time",
-  "timestamp with time zone": "time",
-
-  # Time duration in year to month order
-  "interval year to month": "string",
-
-  # Time duration in day to second order
-  "interval day to second": "string",
-
-  # Logical Boolean (true/false)
-  # boolean does not need to be mapped
-  "bool": "boolean",
-
-  # Type used with HyperLogLog sketches
-  "hllsketch": "string",
-
-  # A superset data type that encompasses all scalar types of Amazon Redshift including complex types such as ARRAY and STRUCTS
-  "super": "string",
-
-  # Variable-length binary value
-  "varbyte": "string",
-  "varbinary": "string",
-  "binary varying": "string",
-
-  # Spatial data
-  "geometry": "geo",
-  "geography": "string",
+    # Signed two-byte integer
+    "smallint": "number",
+    "int2": "number",
+    # Signed four-byte integer
+    "integer": "number",
+    "int": "number",
+    "int4": "number",
+    # Signed eight-byte integer
+    "bigint": "number",
+    "int8": "number",
+    # Exact numeric of selectable precision
+    "decimal": "number",
+    "numeric": "number",
+    # Single precision floating-point number
+    "real": "number",
+    "float4": "number",
+    # Double precision floating-point number
+    "double precision": "number",
+    "float8": "number",
+    "float": "number",
+    # Fixed-length character string
+    "char": "string",
+    "character": "string",
+    "nchar": "string",
+    "bpchar": "string",
+    # Variable-length character string with a user-defined limit
+    "varchar": "string",
+    "character varying": "string",
+    "nvarchar": "string",
+    "text": "string",
+    # Calendar date (year, month, day)
+    "date": "time",
+    # Time of day
+    "time": "time",
+    "time without time zone": "time",
+    # Time of day with time zone
+    "timetz": "time",
+    "time with time zone": "time",
+    # Date and time (without time zone)
+    "timestamp": "time",
+    "timestamp without time zone": "time",
+    # Date and time (with time zone)
+    "timestamptz": "time",
+    "timestamp with time zone": "time",
+    # Time duration in year to month order
+    "interval year to month": "string",
+    # Time duration in day to second order
+    "interval day to second": "string",
+    # Logical Boolean (true/false)
+    # boolean does not need to be mapped
+    "bool": "boolean",
+    # Type used with HyperLogLog sketches
+    "hllsketch": "string",
+    # A superset data type that encompasses all scalar types of Amazon Redshift including complex types such as ARRAY and STRUCTS
+    "super": "string",
+    # Variable-length binary value
+    "varbyte": "string",
+    "varbinary": "string",
+    "binary varying": "string",
+    # Spatial data
+    "geometry": "geo",
+    "geography": "string",
 }
 TYPE_MAPPINGS = {
-  **BIGQUERY_TYPE_MAPPINGS,
-  **REDSHIFT_TYPE_MAPPINGS,
-  **SNOWFLAKE_TYPE_MAPPINGS,
+    **BIGQUERY_TYPE_MAPPINGS,
+    **REDSHIFT_TYPE_MAPPINGS,
+    **SNOWFLAKE_TYPE_MAPPINGS,
 }
 
 
 class Column:
-  def __init__(self, model_name: str, column_dict: dict) -> None:
-    self._model_name = model_name
-    self._column_dict = column_dict
-    pass
-  
-  def __repr__(self) -> str:
-    return str(self._column_dict)
-  
-  @property
-  def name(self) -> str:
-    return self._column_dict['name']
-  
-  @property
-  def description(self) -> str:
-    return self._column_dict['description']
-  
-  @property
-  def sql(self) -> str:
-    return self._column_dict['name']
-  
-  @property
-  def type(self) -> str:
-    if not 'data_type' in self._column_dict or self._column_dict['data_type'] == None:
-      return 'string'
+    def __init__(self, model_name: str, column_dict: dict) -> None:
+        self._model_name = model_name
+        self._column_dict = column_dict
+        pass
 
-    # Normalize the data_type value, downcasing it, and removing extra information.
-    source_data_type = re.sub(r"<.*>", "", re.sub(r"\([^\)]*\)", "", self._column_dict["data_type"].lower()))
+    def __repr__(self) -> str:
+        return str(self._column_dict)
 
-    if source_data_type in TYPE_MAPPINGS:
-      cube_data_type = TYPE_MAPPINGS[source_data_type]
-    else:
-      cube_data_type = source_data_type
+    @property
+    def name(self) -> str:
+        return self._column_dict["name"]
 
-    if cube_data_type not in VALID_DIMENSION_TYPES:
-      raise RuntimeError(f"Unknown column type of {self._model_name}.{self.name}: {self._column_dict['data_type']}")
+    @property
+    def description(self) -> str:
+        return self._column_dict["description"]
 
-    return cube_data_type
+    @property
+    def sql(self) -> str:
+        return self._column_dict["name"]
 
-  @property
-  def meta(self) -> dict:
-    return self._column_dict['meta']
-  
-  @property
-  def primary_key(self) -> bool:
-    """
-    Convention: if the column is marked with the 'primary_key' tag,
-    it will be mapped to a primary key dimension
-    """
-    return 'primary_key' in self._column_dict['tags']
+    @property
+    def type(self) -> str:
+        if (
+            "data_type" not in self._column_dict
+            or self._column_dict["data_type"] is None
+        ):
+            return "string"
 
-  @property
-  def public(self) -> bool:
-    """
-    Convention: if the column is marked with the 'public' tag,
-    it will be mapped to a public dimension
-    """
-    return 'public' in self._column_dict['tags']
+        # Normalize the data_type value, downcasing it, and removing extra information.
+        source_data_type = re.sub(
+            r"<.*>",
+            "",
+            re.sub(r"\([^\)]*\)", "", self._column_dict["data_type"].lower()),
+        )
 
-  def _as_dimension(self) -> dict:
-    data = {}
-    data['name'] = self.name
-    if self.description:
-      data['description'] = self.description
-    data['sql'] = self.sql
-    data['type'] = self.type
-    if self.primary_key:
-      data['primary_key'] = True
-    if self.public:
-      data['public'] = True
-    if self.meta:
-      data['meta'] = self.meta
-    return data
-  
-  def as_dimension(self) -> str:
-    """
-    For use in Jinja:
-    {{ dbt.model('name').column('name').as_dimension() }}
-    """
-    return dump(self._as_dimension(), indent=8)
+        if source_data_type in TYPE_MAPPINGS:
+            cube_data_type = TYPE_MAPPINGS[source_data_type]
+        else:
+            cube_data_type = source_data_type
+
+        if cube_data_type not in VALID_DIMENSION_TYPES:
+            raise RuntimeError(
+                f"Unknown column type of {self._model_name}.{self.name}: {self._column_dict['data_type']}"
+            )
+
+        return cube_data_type
+
+    @property
+    def meta(self) -> dict:
+        return self._column_dict["meta"]
+
+    @property
+    def primary_key(self) -> bool:
+        """
+        Convention: if the column is marked with the 'primary_key' tag,
+        it will be mapped to a primary key dimension
+        """
+        return "primary_key" in self._column_dict["tags"]
+
+    @property
+    def public(self) -> bool:
+        """
+        Convention: if the column is marked with the 'public' tag,
+        it will be mapped to a public dimension
+        """
+        return "public" in self._column_dict["tags"]
+
+    def _as_dimension(self) -> dict:
+        data = {}
+        data["name"] = self.name
+        if self.description:
+            data["description"] = self.description
+        data["sql"] = self.sql
+        data["type"] = self.type
+        if self.primary_key:
+            data["primary_key"] = True
+        if self.public:
+            data["public"] = True
+        if self.meta:
+            data["meta"] = self.meta
+        return data
+
+    def as_dimension(self) -> str:
+        """
+        For use in Jinja:
+        {{ dbt.model('name').column('name').as_dimension() }}
+        """
+        return dump(self._as_dimension(), indent=8)

--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -4,35 +4,36 @@ from urllib.request import urlopen
 from cube_dbt.model import Model
 import locale
 
+
 class Dbt:
-  def __init__(self, manifest: dict) -> None:
-    self.manifest = manifest
-    self.paths = ''
-    self.tags = []
-    self.names = []
-    self._models = None
-    pass
+    def __init__(self, manifest: dict) -> None:
+        self.manifest = manifest
+        self.paths = ""
+        self.tags = []
+        self.names = []
+        self._models = None
+        pass
 
-  @staticmethod
-  def from_file(manifest_path: str, encoding:str = None) -> 'Dbt':
-    """Reads a DBT manifest.json file from local path
+    @staticmethod
+    def from_file(manifest_path: str, encoding: str = None) -> "Dbt":
+        """Reads a DBT manifest.json file from local path
 
-    Args:
-        manifest_path (str): The path to the manifest file, read from the top-level directory of the Cube environment
-        encoding (str, optional): Encoding for the manifest.json file. Uses the system locale preferred encoding if not specified.
+        Args:
+            manifest_path (str): The path to the manifest file, read from the top-level directory of the Cube environment
+            encoding (str, optional): Encoding for the manifest.json file. Uses the system locale preferred encoding if not specified.
 
-    Returns:
-        Dbt: Dbt manifest class to interact with in Cube
-    """
-    if encoding is None:
-        encoding = locale.getpreferredencoding()
-    with open(manifest_path, "r", encoding=encoding) as file:
-        manifest = json.loads(file.read())
-        return Dbt(manifest)
+        Returns:
+            Dbt: Dbt manifest class to interact with in Cube
+        """
+        if encoding is None:
+            encoding = locale.getpreferredencoding()
+        with open(manifest_path, "r", encoding=encoding) as file:
+            manifest = json.loads(file.read())
+            return Dbt(manifest)
 
-  @staticmethod
-  def from_url(manifest_url: str) -> 'Dbt':
-    """
+    @staticmethod
+    def from_url(manifest_url: str) -> "Dbt":
+        """
         Creates an instance of the Dbt class by loading a JSON manifest from a specified URL.
 
         Args:
@@ -40,33 +41,40 @@ class Dbt:
 
         Returns:
             Dbt: An instance of the Dbt class initialized with the manifest loaded from the given URL.
-    """
-    with urlopen(manifest_url) as file:
-        manifest = json.loads(file.read())
-        return Dbt(manifest)
-    
-  def filter(self, paths: list[str]=[], tags: list[str]=[], names: list[str]=[]) -> 'Dbt':
-    self.paths = paths
-    self.tags = tags
-    self.names = names
-    return self
+        """
+        with urlopen(manifest_url) as file:
+            manifest = json.loads(file.read())
+            return Dbt(manifest)
 
-  def _init_models(self):
-    if self._models == None:
-      self._models = list(
-        Model(node) for key, node in self.manifest['nodes'].items()
-        if node['resource_type'] == 'model' and
-        node['config']['materialized'] != 'ephemeral' and
-        (any(node['path'].startswith(path) for path in self.paths) if self.paths else True) and
-        all(tag in node['config']['tags'] for tag in self.tags) and
-        (node['name'] in self.names if self.names else True)
-      )
-  
-  @property
-  def models(self) -> list[Model]:
-    self._init_models()
-    return self._models
-  
-  def model(self, name: str) -> Model:
-    self._init_models()
-    return next(model for model in self._models if model.name == name)
+    def filter(
+        self, paths: list[str] = [], tags: list[str] = [], names: list[str] = []
+    ) -> "Dbt":
+        self.paths = paths
+        self.tags = tags
+        self.names = names
+        return self
+
+    def _init_models(self):
+        if self._models is None:
+            self._models = list(
+                Model(node)
+                for key, node in self.manifest["nodes"].items()
+                if node["resource_type"] == "model"
+                and node["config"]["materialized"] != "ephemeral"
+                and (
+                    any(node["path"].startswith(path) for path in self.paths)
+                    if self.paths
+                    else True
+                )
+                and all(tag in node["config"]["tags"] for tag in self.tags)
+                and (node["name"] in self.names if self.names else True)
+            )
+
+    @property
+    def models(self) -> list[Model]:
+        self._init_models()
+        return self._models
+
+    def model(self, name: str) -> Model:
+        self._init_models()
+        return next(model for model in self._models if model.name == name)

--- a/src/cube_dbt/dump.py
+++ b/src/cube_dbt/dump.py
@@ -1,28 +1,31 @@
 import yaml
 
+
 class SafeString(str):
     is_safe: bool
 
     def __init__(self, v: str):
         self.is_safe = True
 
+
 class Dumper(yaml.Dumper):
-  def increase_indent(self, flow=False, indentless=False):
-    return super(Dumper, self).increase_indent(flow, indentless)
+    def increase_indent(self, flow=False, indentless=False):
+        return super(Dumper, self).increase_indent(flow, indentless)
+
 
 def indent_string(string: str, indent: int) -> str:
-  return '\n'.join(
-    (' ' * indent if i > 0 else '') +
-    s for i, s in enumerate(string.split('\n'))
-  )
+    return "\n".join(
+        (" " * indent if i > 0 else "") + s for i, s in enumerate(string.split("\n"))
+    )
 
-def dump(data, indent: int=0) -> str:
-  dump = yaml.dump(
-    data,
-    Dumper=Dumper,
-    sort_keys=False,
-    default_flow_style=False,
-    allow_unicode=True,
-    indent=0
-  )
-  return SafeString(indent_string(dump, indent))
+
+def dump(data, indent: int = 0) -> str:
+    dump = yaml.dump(
+        data,
+        Dumper=Dumper,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+        indent=0,
+    )
+    return SafeString(indent_string(dump, indent))

--- a/src/cube_dbt/model.py
+++ b/src/cube_dbt/model.py
@@ -1,93 +1,96 @@
 from cube_dbt.column import Column
 from cube_dbt.dump import dump, SafeString
 
+
 class Model:
-  def __init__(self, model_dict: dict) -> None:
-    self._model_dict = model_dict
-    self._columns = None
-    self._primary_key = None
-    pass
+    def __init__(self, model_dict: dict) -> None:
+        self._model_dict = model_dict
+        self._columns = None
+        self._primary_key = None
+        pass
 
-  def __repr__(self) -> str:
-    return str(self._model_dict)
+    def __repr__(self) -> str:
+        return str(self._model_dict)
 
-  def _init_columns(self) -> None:
-    if self._columns == None:
-      self._columns = list(
-        Column(self.name, column) for key, column in self._model_dict['columns'].items()
-      )
-      self._detect_primary_key()
+    def _init_columns(self) -> None:
+        if self._columns is None:
+            self._columns = list(
+                Column(self.name, column)
+                for key, column in self._model_dict["columns"].items()
+            )
+            self._detect_primary_key()
 
-  def _detect_primary_key(self) -> None:
-    candidates = list(
-      column for column in self._columns
-      if column.primary_key
-    )
+    def _detect_primary_key(self) -> None:
+        candidates = list(column for column in self._columns if column.primary_key)
 
-    if len(candidates) > 1:
-      column_names = list(column.name for column in candidates)
-      raise RuntimeError(f"More than one primary key column found in {self.name}: {', '.join(column_names)}")
+        if len(candidates) > 1:
+            column_names = list(column.name for column in candidates)
+            raise RuntimeError(
+                f"More than one primary key column found in {self.name}: {', '.join(column_names)}"
+            )
 
-    self._primary_key = candidates[0] if len(candidates) == 1 else None
-  
-  @property
-  def name(self) -> str:
-    return self._model_dict['name']
-  
-  @property
-  def description(self) -> str:
-    return self._model_dict['description']
-  
-  @property
-  def sql_table(self) -> str:
-    if 'relation_name' in self._model_dict:
-      return self._model_dict['relation_name']
-    else:
-      database = self._model_dict['database']
-      schema = self._model_dict['schema']
-      name = self._model_dict['alias'] if 'alias' in self._model_dict else self._model_dict['name']
-      return f"`{database}`.`{schema}`.`{name}`"
+        self._primary_key = candidates[0] if len(candidates) == 1 else None
 
-  @property
-  def columns(self) -> list[Column]:
-    self._init_columns()
-    return self._columns
-  
-  def column(self, name: str) -> Column:
-    self._init_columns()
-    return next(column for column in self._columns if column.name == name)
-  
-  @property
-  def primary_key(self) -> Column or None:
-    self._init_columns()
-    return self._primary_key
+    @property
+    def name(self) -> str:
+        return self._model_dict["name"]
 
-  def _as_cube(self) -> dict:
-    data = {}
-    data['name'] = self.name
-    if self.description:
-      data['description'] = self.description
-    data['sql_table'] = self.sql_table
-    return data
+    @property
+    def description(self) -> str:
+        return self._model_dict["description"]
 
-  def as_cube(self) -> str:
-    """
-    For use in Jinja:
-    {{ dbt.model('name').as_cube() }}
-    """
-    return dump(self._as_cube(), indent=4)
-  
-  def _as_dimensions(self, skip: list[str]=[]) -> list:
-    return list(
-      column._as_dimension()
-      for column in self.columns
-      if column.name not in skip
-    )
-  
-  def as_dimensions(self, skip: list[str]=[]) -> str:
-    """
-    For use in Jinja:
-    {{ dbt.model('name').as_dimensions(skip=['id']) }}
-    """
-    dimensions = self._as_dimensions(skip)
-    return dump(dimensions, indent=6) if dimensions else SafeString('')
+    @property
+    def sql_table(self) -> str:
+        if "relation_name" in self._model_dict:
+            return self._model_dict["relation_name"]
+        else:
+            database = self._model_dict["database"]
+            schema = self._model_dict["schema"]
+            name = (
+                self._model_dict["alias"]
+                if "alias" in self._model_dict
+                else self._model_dict["name"]
+            )
+            return f"`{database}`.`{schema}`.`{name}`"
+
+    @property
+    def columns(self) -> list[Column]:
+        self._init_columns()
+        return self._columns
+
+    def column(self, name: str) -> Column:
+        self._init_columns()
+        return next(column for column in self._columns if column.name == name)
+
+    @property
+    def primary_key(self) -> Column or None:
+        self._init_columns()
+        return self._primary_key
+
+    def _as_cube(self) -> dict:
+        data = {}
+        data["name"] = self.name
+        if self.description:
+            data["description"] = self.description
+        data["sql_table"] = self.sql_table
+        return data
+
+    def as_cube(self) -> str:
+        """
+        For use in Jinja:
+        {{ dbt.model('name').as_cube() }}
+        """
+        return dump(self._as_cube(), indent=4)
+
+    def _as_dimensions(self, skip: list[str] = []) -> list:
+        return list(
+            column._as_dimension() for column in self.columns if column.name not in skip
+        )
+
+    def as_dimensions(self, skip: list[str] = []) -> str:
+        """
+        For use in Jinja:
+        {{ dbt.model('name').as_dimensions(skip=['id']) }}
+        """
+        dimensions = self._as_dimensions(skip)
+        return dump(dimensions, indent=6) if dimensions else SafeString("")

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,122 +1,109 @@
 from pytest import raises
 from cube_dbt import Column
 
+
 class TestColumn:
-  def test_no_type(self):
-    """
-    If no type, then assume 'string'
-    """
-    column_dict = {}
-    column = Column('model', column_dict)
-    assert column.type == 'string'
+    def test_no_type(self):
+        """
+        If no type, then assume 'string'
+        """
+        column_dict = {}
+        column = Column("model", column_dict)
+        assert column.type == "string"
 
-  def test_none_type(self):
-    """
-    If type is None, then assume 'string'
-    """
-    column_dict = {
-      'data_type': None
-    }
-    column = Column('model', column_dict)
-    assert column.type == 'string'
+    def test_none_type(self):
+        """
+        If type is None, then assume 'string'
+        """
+        column_dict = {"data_type": None}
+        column = Column("model", column_dict)
+        assert column.type == "string"
 
-  def test_unknown_type(self):
-    """
-    If type is unknown, then raise an exception
-    """
-    column_dict = {
-      'name': 'column',
-      'data_type': 'unknown'
-    }
-    column = Column('model', column_dict)
-    with raises(RuntimeError):
-      column.type
+    def test_unknown_type(self):
+        """
+        If type is unknown, then raise an exception
+        """
+        column_dict = {"name": "column", "data_type": "unknown"}
+        column = Column("model", column_dict)
+        with raises(RuntimeError):
+            column.type
 
-  def test_known_type(self):
-    """
-    If type is known, then map it
-    """
-    column_dict = {
-      'data_type': 'numeric'
-    }
-    column = Column('model', column_dict)
-    assert column.type == 'number'
+    def test_known_type(self):
+        """
+        If type is known, then map it
+        """
+        column_dict = {"data_type": "numeric"}
+        column = Column("model", column_dict)
+        assert column.type == "number"
 
-  def test_known_type_but_uppercase(self):
-    """
-    If type is known, then map it
-    """
-    column_dict = {
-      'data_type': 'STRING'
-    }
-    column = Column('model', column_dict)
-    assert column.type == 'string'
+    def test_known_type_but_uppercase(self):
+        """
+        If type is known, then map it
+        """
+        column_dict = {"data_type": "STRING"}
+        column = Column("model", column_dict)
+        assert column.type == "string"
 
-  def test_known_type_but_with_one_extra_info(self):
-    """
-    If type is known, then map it
-    """
-    column_dict = {
-      'data_type': 'timestamp(3)'
-    }
-    column = Column('model', column_dict)
-    assert column.type == 'time'
+    def test_known_type_but_with_one_extra_info(self):
+        """
+        If type is known, then map it
+        """
+        column_dict = {"data_type": "timestamp(3)"}
+        column = Column("model", column_dict)
+        assert column.type == "time"
 
-  def test_known_type_but_with_two_extra_info(self):
-    """
-    If type is known, then map it
-    """
-    column_dict = {
-      'data_type': 'numeric(38,0)'
-    }
-    column = Column('model', column_dict)
-    assert column.type == 'number'
+    def test_known_type_but_with_two_extra_info(self):
+        """
+        If type is known, then map it
+        """
+        column_dict = {"data_type": "numeric(38,0)"}
+        column = Column("model", column_dict)
+        assert column.type == "number"
 
-  def test_known_type_but_with_two_extra_info_of_different_types(self):
-    """
-    If type is known, then map it
-    """
-    column_dict = {
-      'data_type': 'VECTOR(FLOAT, 256)'
-    }
-    column = Column('model', column_dict)
-    assert column.type == 'string'
+    def test_known_type_but_with_two_extra_info_of_different_types(self):
+        """
+        If type is known, then map it
+        """
+        column_dict = {"data_type": "VECTOR(FLOAT, 256)"}
+        column = Column("model", column_dict)
+        assert column.type == "string"
 
-  def test_known_bigquery_type_but_with_extra_info(self):
-    """
-    If type is known, then map it
-    """
-    column_dict = {
-      'data_type': 'ARRAY<STRUCT<ARRAY<INT64>>>'
-    }
-    column = Column('model', column_dict)
-    assert column.type == 'string'
+    def test_known_bigquery_type_but_with_extra_info(self):
+        """
+        If type is known, then map it
+        """
+        column_dict = {"data_type": "ARRAY<STRUCT<ARRAY<INT64>>>"}
+        column = Column("model", column_dict)
+        assert column.type == "string"
 
-  def test_as_dimension(self):
-    column_dict = {
-      'name': 'column',
-      'description': '',
-      'meta': {},
-      'data_type': 'numeric',
-      'tags': []
-    }
-    column = Column('model', column_dict)
-    assert column._as_dimension() == {
-      'name': 'column',
-      'sql': 'column',
-      'type': 'number'
-    }
+    def test_as_dimension(self):
+        column_dict = {
+            "name": "column",
+            "description": "",
+            "meta": {},
+            "data_type": "numeric",
+            "tags": [],
+        }
+        column = Column("model", column_dict)
+        assert column._as_dimension() == {
+            "name": "column",
+            "sql": "column",
+            "type": "number",
+        }
 
-  def test_as_dimension_render(self):
-    column_dict = {
-      'name': 'column',
-      'description': '',
-      'meta': {},
-      'data_type': 'numeric',
-      'tags': []
-    }
-    column = Column('model', column_dict)
-    assert column.as_dimension() == """name: column
+    def test_as_dimension_render(self):
+        column_dict = {
+            "name": "column",
+            "description": "",
+            "meta": {},
+            "data_type": "numeric",
+            "tags": [],
+        }
+        column = Column("model", column_dict)
+        assert (
+            column.as_dimension()
+            == """name: column
         sql: column
         type: number
         """
+        )

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -1,191 +1,157 @@
-import os 
+import os
 
-from pytest import raises
 from cube_dbt import Dbt
 
+
 class TestDbt:
-  def test_from_file(self):
-    directory_path = os.path.dirname(os.path.realpath(__file__))
-    dbt = Dbt.from_file(directory_path + '/manifest.json')
-    model_names = list(model.name for model in dbt.models)
-    assert model_names == [
-      'users_copy',
-      'orders_copy',
-      'line_items_copy',
-      'products_copy'
-    ]
+    def test_from_file(self):
+        directory_path = os.path.dirname(os.path.realpath(__file__))
+        dbt = Dbt.from_file(directory_path + "/manifest.json")
+        model_names = list(model.name for model in dbt.models)
+        assert model_names == [
+            "users_copy",
+            "orders_copy",
+            "line_items_copy",
+            "products_copy",
+        ]
 
-  def test_load_only_models(self):
-    """
-    Only load nodes with resource type 'model'
-    """
-    manifest = {
-      'nodes': {
-        'model.jaffle_shop.users_copy': {
-          'name': 'users_copy',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'table'
-          },
-          'path': 'example/users_copy.sql'
-        },
-        'snapshot.jaffle_shop.snapshot_1': {
-          'name': 'snapshot_1',
-          'resource_type': 'snapshot'
+    def test_load_only_models(self):
+        """
+        Only load nodes with resource type 'model'
+        """
+        manifest = {
+            "nodes": {
+                "model.jaffle_shop.users_copy": {
+                    "name": "users_copy",
+                    "resource_type": "model",
+                    "config": {"materialized": "table"},
+                    "path": "example/users_copy.sql",
+                },
+                "snapshot.jaffle_shop.snapshot_1": {
+                    "name": "snapshot_1",
+                    "resource_type": "snapshot",
+                },
+            }
         }
-      }
-    }
-    dbt = Dbt(manifest)
-    model_names = list(model.name for model in dbt.models)
-    assert model_names == ['users_copy']
+        dbt = Dbt(manifest)
+        model_names = list(model.name for model in dbt.models)
+        assert model_names == ["users_copy"]
 
-  def test_do_not_load_ephemeral_models(self):
-    """
-    Don't load models that are not materialized to the database
-    """
-    manifest = {
-      'nodes': {
-        'model.jaffle_shop.users_copy': {
-          'name': 'users_copy',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'table'
-          },
-          'path': 'example/users_copy.sql'
-        },
-        'model.jaffle_shop.users_copy_2': {
-          'name': 'users_copy_2',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'view'
-          },
-          'path': 'example/users_copy_2.sql'
-        },
-        'model.jaffle_shop.users_copy_3': {
-          'name': 'users_copy_3',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'incremental'
-          },
-          'path': 'example/users_copy_3.sql'
-        },
-        'model.jaffle_shop.users_copy_4': {
-          'name': 'users_copy_4',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'ephemeral'
-          },
-          'path': 'example/users_copy_4.sql'
+    def test_do_not_load_ephemeral_models(self):
+        """
+        Don't load models that are not materialized to the database
+        """
+        manifest = {
+            "nodes": {
+                "model.jaffle_shop.users_copy": {
+                    "name": "users_copy",
+                    "resource_type": "model",
+                    "config": {"materialized": "table"},
+                    "path": "example/users_copy.sql",
+                },
+                "model.jaffle_shop.users_copy_2": {
+                    "name": "users_copy_2",
+                    "resource_type": "model",
+                    "config": {"materialized": "view"},
+                    "path": "example/users_copy_2.sql",
+                },
+                "model.jaffle_shop.users_copy_3": {
+                    "name": "users_copy_3",
+                    "resource_type": "model",
+                    "config": {"materialized": "incremental"},
+                    "path": "example/users_copy_3.sql",
+                },
+                "model.jaffle_shop.users_copy_4": {
+                    "name": "users_copy_4",
+                    "resource_type": "model",
+                    "config": {"materialized": "ephemeral"},
+                    "path": "example/users_copy_4.sql",
+                },
+            }
         }
-      }
-    }
-    dbt = Dbt(manifest)
-    model_names = list(model.name for model in dbt.models)
-    assert model_names == [
-      'users_copy',
-      'users_copy_2',
-      'users_copy_3'
-    ]
+        dbt = Dbt(manifest)
+        model_names = list(model.name for model in dbt.models)
+        assert model_names == ["users_copy", "users_copy_2", "users_copy_3"]
 
-  def test_load_models_by_path(self):
-    manifest = {
-      'nodes': {
-        'model.jaffle_shop.users_copy': {
-          'name': 'users_copy',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'table'
-          },
-          'path': 'example/users_copy.sql'
-        },
-        'model.jaffle_shop.users_copy_2': {
-          'name': 'users_copy_2',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'view'
-          },
-          'path': 'marts/users_copy_2.sql'
+    def test_load_models_by_path(self):
+        manifest = {
+            "nodes": {
+                "model.jaffle_shop.users_copy": {
+                    "name": "users_copy",
+                    "resource_type": "model",
+                    "config": {"materialized": "table"},
+                    "path": "example/users_copy.sql",
+                },
+                "model.jaffle_shop.users_copy_2": {
+                    "name": "users_copy_2",
+                    "resource_type": "model",
+                    "config": {"materialized": "view"},
+                    "path": "marts/users_copy_2.sql",
+                },
+            }
         }
-      }
-    }
-    dbt = Dbt(manifest).filter(paths=['marts/'])
-    model_names = list(model.name for model in dbt.models)
-    assert model_names == ['users_copy_2']
+        dbt = Dbt(manifest).filter(paths=["marts/"])
+        model_names = list(model.name for model in dbt.models)
+        assert model_names == ["users_copy_2"]
 
-  def test_load_models_by_tag(self):
-    manifest = {
-      'nodes': {
-        'model.jaffle_shop.users_copy': {
-          'name': 'users_copy',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'table',
-            'tags': [
-              'cube'
-            ]
-          },
-          'path': 'example/users_copy.sql'
-        },
-        'model.jaffle_shop.users_copy_2': {
-          'name': 'users_copy_2',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'view',
-            'tags': []
-          },
-          'path': 'marts/users_copy_2.sql'
+    def test_load_models_by_tag(self):
+        manifest = {
+            "nodes": {
+                "model.jaffle_shop.users_copy": {
+                    "name": "users_copy",
+                    "resource_type": "model",
+                    "config": {"materialized": "table", "tags": ["cube"]},
+                    "path": "example/users_copy.sql",
+                },
+                "model.jaffle_shop.users_copy_2": {
+                    "name": "users_copy_2",
+                    "resource_type": "model",
+                    "config": {"materialized": "view", "tags": []},
+                    "path": "marts/users_copy_2.sql",
+                },
+            }
         }
-      }
-    }
-    dbt = Dbt(manifest).filter(tags=['cube'])
-    model_names = list(model.name for model in dbt.models)
-    assert model_names == ['users_copy']
+        dbt = Dbt(manifest).filter(tags=["cube"])
+        model_names = list(model.name for model in dbt.models)
+        assert model_names == ["users_copy"]
 
-  def test_load_models_by_name(self):
-    manifest = {
-      'nodes': {
-        'model.jaffle_shop.users_copy': {
-          'name': 'users_copy',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'table'
-          },
-          'path': 'example/users_copy.sql'
-        },
-        'model.jaffle_shop.users_copy_2': {
-          'name': 'users_copy_2',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'view'
-          },
-          'path': 'marts/users_copy_2.sql'
+    def test_load_models_by_name(self):
+        manifest = {
+            "nodes": {
+                "model.jaffle_shop.users_copy": {
+                    "name": "users_copy",
+                    "resource_type": "model",
+                    "config": {"materialized": "table"},
+                    "path": "example/users_copy.sql",
+                },
+                "model.jaffle_shop.users_copy_2": {
+                    "name": "users_copy_2",
+                    "resource_type": "model",
+                    "config": {"materialized": "view"},
+                    "path": "marts/users_copy_2.sql",
+                },
+            }
         }
-      }
-    }
-    dbt = Dbt(manifest).filter(names=['users_copy_2'])
-    model_names = list(model.name for model in dbt.models)
-    assert model_names == ['users_copy_2']
+        dbt = Dbt(manifest).filter(names=["users_copy_2"])
+        model_names = list(model.name for model in dbt.models)
+        assert model_names == ["users_copy_2"]
 
-  def test_model(self):
-    manifest = {
-      'nodes': {
-        'model.jaffle_shop.users_copy': {
-          'name': 'users_copy',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'table'
-          },
-          'path': 'example/users_copy.sql'
-        },
-        'model.jaffle_shop.users_copy_2': {
-          'name': 'users_copy_2',
-          'resource_type': 'model',
-          'config': {
-            'materialized': 'view'
-          },
-          'path': 'marts/users_copy_2.sql'
+    def test_model(self):
+        manifest = {
+            "nodes": {
+                "model.jaffle_shop.users_copy": {
+                    "name": "users_copy",
+                    "resource_type": "model",
+                    "config": {"materialized": "table"},
+                    "path": "example/users_copy.sql",
+                },
+                "model.jaffle_shop.users_copy_2": {
+                    "name": "users_copy_2",
+                    "resource_type": "model",
+                    "config": {"materialized": "view"},
+                    "path": "marts/users_copy_2.sql",
+                },
+            }
         }
-      }
-    }
-    dbt = Dbt(manifest)
-    assert dbt.model('users_copy_2').name == 'users_copy_2'
+        dbt = Dbt(manifest)
+        assert dbt.model("users_copy_2").name == "users_copy_2"

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,18 +1,19 @@
 from cube_dbt.dump import indent_string
 
-class TestIndentString:
-  def test_single_line_string(self):
-    """
-    First line is not indented
-    """
-    input = 'abc'
-    output = indent_string(input, 2)
-    assert output == 'abc'
 
-  def test_milti_line_string(self):
-    """
-    First line is not indented, all other lines are indented
-    """
-    input = 'abc\ndef\nghi'
-    output = indent_string(input, 2)
-    assert output == 'abc\n  def\n  ghi'
+class TestIndentString:
+    def test_single_line_string(self):
+        """
+        First line is not indented
+        """
+        input = "abc"
+        output = indent_string(input, 2)
+        assert output == "abc"
+
+    def test_milti_line_string(self):
+        """
+        First line is not indented, all other lines are indented
+        """
+        input = "abc\ndef\nghi"
+        output = indent_string(input, 2)
+        assert output == "abc\n  def\n  ghi"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,275 +1,226 @@
 from pytest import raises
 from cube_dbt import Model
 
+
 class TestModel:
-  def test_sql_table_with_relation(self):
-    """
-    If a relation is present, then use it
-    """
-    model_dict = {
-      'relation_name': '"db"."schema"."table"',
-      'database': 'db_2',
-      'schema': 'schema_2',
-      'name': 'table_2'
-    }
-    model = Model(model_dict)
-    assert model.sql_table == '"db"."schema"."table"'
-
-  def test_sql_table_without_relation(self):
-    """
-    If a relation is not present, then compose it
-    """
-    model_dict = {
-      'database': 'db_2',
-      'schema': 'schema_2',
-      'name': 'table_2'
-    }
-    model = Model(model_dict)
-    assert model.sql_table == '`db_2`.`schema_2`.`table_2`'
-
-  def test_sql_table_without_relation_with_alias(self):
-    """
-    If a relation is not present and an alias is,
-    then compose it using that alias 
-    """
-    model_dict = {
-      'database': 'db_2',
-      'schema': 'schema_2',
-      'name': 'table_2',
-      'alias': 'alias_2'
-    }
-    model = Model(model_dict)
-    assert model.sql_table == '`db_2`.`schema_2`.`alias_2`'
-
-  def test_detect_primary_key_no_columns(self):
-    """
-    If a model has no columns with a 'primary key'
-    tag, then detect no primary keys
-    """
-    model_dict = {
-      'name': 'model',
-      'columns': {
-        'id': {
-          'name': 'id',
-          'data_type': 'numeric',
-          'tags': []
-        },
-        'status': {
-          'name': 'status',
-          'data_type': None,
-          'tags': []
+    def test_sql_table_with_relation(self):
+        """
+        If a relation is present, then use it
+        """
+        model_dict = {
+            "relation_name": '"db"."schema"."table"',
+            "database": "db_2",
+            "schema": "schema_2",
+            "name": "table_2",
         }
-      }
-    }
-    model = Model(model_dict)
-    assert model.primary_key == None
+        model = Model(model_dict)
+        assert model.sql_table == '"db"."schema"."table"'
 
-  def test_detect_primary_key_one_column(self):
-    """
-    If a model has one and only one column with a 'primary key'
-    tag, then use it as a primary key
-    """
-    model_dict = {
-      'name': 'model',
-      'columns': {
-        'id': {
-          'name': 'id',
-          'data_type': 'numeric',
-          'tags': [
-            'primary_key'
-          ]
-        },
-        'status': {
-          'name': 'status',
-          'data_type': None,
-          'tags': []
+    def test_sql_table_without_relation(self):
+        """
+        If a relation is not present, then compose it
+        """
+        model_dict = {"database": "db_2", "schema": "schema_2", "name": "table_2"}
+        model = Model(model_dict)
+        assert model.sql_table == "`db_2`.`schema_2`.`table_2`"
+
+    def test_sql_table_without_relation_with_alias(self):
+        """
+        If a relation is not present and an alias is,
+        then compose it using that alias
+        """
+        model_dict = {
+            "database": "db_2",
+            "schema": "schema_2",
+            "name": "table_2",
+            "alias": "alias_2",
         }
-      }
-    }
-    model = Model(model_dict)
-    assert model.primary_key != None
-    assert model.primary_key.name == 'id'
+        model = Model(model_dict)
+        assert model.sql_table == "`db_2`.`schema_2`.`alias_2`"
 
-  def test_detect_primary_key_two_columns(self):
-    """
-    If a model has more than one column with a 'primary_key'
-    tag, then raise an exception
-    """
-    model_dict = {
-      'name': 'model',
-      'columns': {
-        'id': {
-          'name': 'id',
-          'data_type': 'numeric',
-          'tags': [
-            'primary_key'
-          ]
-        },
-        'status': {
-          'name': 'status',
-          'data_type': None,
-          'tags': [
-            'primary_key'
-          ]
+    def test_detect_primary_key_no_columns(self):
+        """
+        If a model has no columns with a 'primary key'
+        tag, then detect no primary keys
+        """
+        model_dict = {
+            "name": "model",
+            "columns": {
+                "id": {"name": "id", "data_type": "numeric", "tags": []},
+                "status": {"name": "status", "data_type": None, "tags": []},
+            },
         }
-      }
-    }
-    model = Model(model_dict)
-    with raises(RuntimeError):
-      model.primary_key
+        model = Model(model_dict)
+        assert model.primary_key is None
 
-  def test_as_cube(self):
-    model_dict = {
-      'relation_name': '"db"."schema"."table"',
-      'database': 'db_2',
-      'schema': 'schema_2',
-      'name': 'table_2',
-      'description': ''
-    }
-    model = Model(model_dict)
-    assert model._as_cube() == {
-      'name': 'table_2',
-      'sql_table': '"db"."schema"."table"'
-    }
+    def test_detect_primary_key_one_column(self):
+        """
+        If a model has one and only one column with a 'primary key'
+        tag, then use it as a primary key
+        """
+        model_dict = {
+            "name": "model",
+            "columns": {
+                "id": {"name": "id", "data_type": "numeric", "tags": ["primary_key"]},
+                "status": {"name": "status", "data_type": None, "tags": []},
+            },
+        }
+        model = Model(model_dict)
+        assert model.primary_key is not None
+        assert model.primary_key.name == "id"
 
-  def test_as_cube_render(self):
-    model_dict = {
-      'relation_name': '"db"."schema"."table"',
-      'database': 'db_2',
-      'schema': 'schema_2',
-      'name': 'table_2',
-      'description': ''
-    }
-    model = Model(model_dict)
-    assert model.as_cube() == """name: table_2
+    def test_detect_primary_key_two_columns(self):
+        """
+        If a model has more than one column with a 'primary_key'
+        tag, then raise an exception
+        """
+        model_dict = {
+            "name": "model",
+            "columns": {
+                "id": {"name": "id", "data_type": "numeric", "tags": ["primary_key"]},
+                "status": {
+                    "name": "status",
+                    "data_type": None,
+                    "tags": ["primary_key"],
+                },
+            },
+        }
+        model = Model(model_dict)
+        with raises(RuntimeError):
+            model.primary_key
+
+    def test_as_cube(self):
+        model_dict = {
+            "relation_name": '"db"."schema"."table"',
+            "database": "db_2",
+            "schema": "schema_2",
+            "name": "table_2",
+            "description": "",
+        }
+        model = Model(model_dict)
+        assert model._as_cube() == {
+            "name": "table_2",
+            "sql_table": '"db"."schema"."table"',
+        }
+
+    def test_as_cube_render(self):
+        model_dict = {
+            "relation_name": '"db"."schema"."table"',
+            "database": "db_2",
+            "schema": "schema_2",
+            "name": "table_2",
+            "description": "",
+        }
+        model = Model(model_dict)
+        assert (
+            model.as_cube()
+            == """name: table_2
     sql_table: '"db"."schema"."table"'
     """
+        )
 
-  def test_as_dimensions(self):
-    model_dict = {
-      'name': 'model',
-      'columns': {
-        'id': {
-          'name': 'id',
-          'description': '',
-          'meta': {},
-          'data_type': 'numeric',
-          'tags': []
-        },
-        'status': {
-          'name': 'status',
-          'description': '',
-          'meta': {},
-          'data_type': None,
-          'tags': []
+    def test_as_dimensions(self):
+        model_dict = {
+            "name": "model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "numeric",
+                    "tags": [],
+                },
+                "status": {
+                    "name": "status",
+                    "description": "",
+                    "meta": {},
+                    "data_type": None,
+                    "tags": [],
+                },
+            },
         }
-      }
-    }
-    model = Model(model_dict)
-    assert model._as_dimensions() == [
-      {
-        'name': 'id',
-        'sql': 'id',
-        'type': 'number'
-      },
-      {
-        'name': 'status',
-        'sql': 'status',
-        'type': 'string'
-      }
-    ]
+        model = Model(model_dict)
+        assert model._as_dimensions() == [
+            {"name": "id", "sql": "id", "type": "number"},
+            {"name": "status", "sql": "status", "type": "string"},
+        ]
 
-  def test_as_dimensions_with_primary_key(self):
-    model_dict = {
-      'name': 'model',
-      'columns': {
-        'id': {
-          'name': 'id',
-          'description': '',
-          'meta': {},
-          'data_type': 'numeric',
-          'tags': [
-            'primary_key'
-          ]
-        },
-        'status': {
-          'name': 'status',
-          'description': '',
-          'meta': {},
-          'data_type': None,
-          'tags': []
+    def test_as_dimensions_with_primary_key(self):
+        model_dict = {
+            "name": "model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "numeric",
+                    "tags": ["primary_key"],
+                },
+                "status": {
+                    "name": "status",
+                    "description": "",
+                    "meta": {},
+                    "data_type": None,
+                    "tags": [],
+                },
+            },
         }
-      }
-    }
-    model = Model(model_dict)
-    assert model._as_dimensions() == [
-      {
-        'name': 'id',
-        'sql': 'id',
-        'type': 'number',
-        'primary_key': True
-      },
-      {
-        'name': 'status',
-        'sql': 'status',
-        'type': 'string'
-      }
-    ]
+        model = Model(model_dict)
+        assert model._as_dimensions() == [
+            {"name": "id", "sql": "id", "type": "number", "primary_key": True},
+            {"name": "status", "sql": "status", "type": "string"},
+        ]
 
-  def test_as_dimensions_with_skipped_columns(self):
-    model_dict = {
-      'name': 'model',
-      'columns': {
-        'id': {
-          'name': 'id',
-          'description': '',
-          'meta': {},
-          'data_type': 'numeric',
-          'tags': []
-        },
-        'status': {
-          'name': 'status',
-          'description': '',
-          'meta': {},
-          'data_type': None,
-          'tags': []
+    def test_as_dimensions_with_skipped_columns(self):
+        model_dict = {
+            "name": "model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "numeric",
+                    "tags": [],
+                },
+                "status": {
+                    "name": "status",
+                    "description": "",
+                    "meta": {},
+                    "data_type": None,
+                    "tags": [],
+                },
+            },
         }
-      }
-    }
-    model = Model(model_dict)
-    assert model._as_dimensions(skip=['id']) == [
-      {
-        'name': 'status',
-        'sql': 'status',
-        'type': 'string'
-      }
-    ]
+        model = Model(model_dict)
+        assert model._as_dimensions(skip=["id"]) == [
+            {"name": "status", "sql": "status", "type": "string"}
+        ]
 
-  def test_as_dimensions_render(self):
-    model_dict = {
-      'name': 'model',
-      'columns': {
-        'id': {
-          'name': 'id',
-          'description': '',
-          'meta': {},
-          'data_type': 'numeric',
-          'tags': [
-            'primary_key'
-          ]
-        },
-        'status': {
-          'name': 'status',
-          'description': '',
-          'meta': {},
-          'data_type': None,
-          'tags': []
+    def test_as_dimensions_render(self):
+        model_dict = {
+            "name": "model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "numeric",
+                    "tags": ["primary_key"],
+                },
+                "status": {
+                    "name": "status",
+                    "description": "",
+                    "meta": {},
+                    "data_type": None,
+                    "tags": [],
+                },
+            },
         }
-      }
-    }
 
-    model = Model(model_dict)
-    assert model.as_dimensions() == """- name: id
+        model = Model(model_dict)
+        assert (
+            model.as_dimensions()
+            == """- name: id
         sql: id
         type: number
         primary_key: true
@@ -277,12 +228,10 @@ class TestModel:
         sql: status
         type: string
       """
+        )
 
-  def test_as_dimensions_render_when_empty(self):
-    model_dict = {
-      'name': 'model',
-      'columns': {}
-    }
+    def test_as_dimensions_render_when_empty(self):
+        model_dict = {"name": "model", "columns": {}}
 
-    model = Model(model_dict)
-    assert model.as_dimensions() == ''
+        model = Model(model_dict)
+        assert model.as_dimensions() == ""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.8"
+requires-python = ">=3.10, <3.12"
 
 [[package]]
 name = "colorama"
@@ -12,21 +12,25 @@ wheels = [
 
 [[package]]
 name = "cube-dbt"
-version = "0.0.0.post24.dev0+e93de8a"
+version = "0.6.0.post11.dev0+153e809"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.2" },
-    { name = "pyyaml", specifier = ">=6.0.1" },
+requires-dist = [{ name = "pyyaml", specifier = ">=6.0.1" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [[package]]
@@ -106,40 +110,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
     { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
     { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
-    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
-    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
-    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
-    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
-    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
-    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
-    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
-    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
-    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
-    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
-    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
-    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
-    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
-    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
-    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
-    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
-    { url = "https://files.pythonhosted.org/packages/74/d9/323a59d506f12f498c2097488d80d16f4cf965cee1791eab58b56b19f47a/PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a", size = 183218 },
-    { url = "https://files.pythonhosted.org/packages/74/cc/20c34d00f04d785f2028737e2e2a8254e1425102e730fee1d6396f832577/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5", size = 728067 },
-    { url = "https://files.pythonhosted.org/packages/20/52/551c69ca1501d21c0de51ddafa8c23a0191ef296ff098e98358f69080577/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d", size = 757812 },
-    { url = "https://files.pythonhosted.org/packages/fd/7f/2c3697bba5d4aa5cc2afe81826d73dfae5f049458e44732c7a0938baa673/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083", size = 746531 },
-    { url = "https://files.pythonhosted.org/packages/8c/ab/6226d3df99900e580091bb44258fde77a8433511a86883bd4681ea19a858/PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706", size = 800820 },
-    { url = "https://files.pythonhosted.org/packages/a0/99/a9eb0f3e710c06c5d922026f6736e920d431812ace24aae38228d0d64b04/PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a", size = 145514 },
-    { url = "https://files.pythonhosted.org/packages/75/8a/ee831ad5fafa4431099aa4e078d4c8efd43cd5e48fbc774641d233b683a9/PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff", size = 162702 },
-    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777 },
-    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318 },
-    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891 },
-    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614 },
-    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360 },
-    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006 },
-    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577 },
-    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593 },
-    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2b/01245f4f3a727d60bebeacd7ee6d22586c7f62380a2597ddb22c2f45d018/ruff-0.8.2.tar.gz", hash = "sha256:b84f4f414dda8ac7f75075c1fa0b905ac0ff25361f42e6d5da681a465e0f78e5", size = 3349020 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/29/366be70216dba1731a00a41f2f030822b0c96c7c4f3b2c0cdce15cbace74/ruff-0.8.2-py3-none-linux_armv6l.whl", hash = "sha256:c49ab4da37e7c457105aadfd2725e24305ff9bc908487a9bf8d548c6dad8bb3d", size = 10530649 },
+    { url = "https://files.pythonhosted.org/packages/63/82/a733956540bb388f00df5a3e6a02467b16c0e529132625fe44ce4c5fb9c7/ruff-0.8.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ec016beb69ac16be416c435828be702ee694c0d722505f9c1f35e1b9c0cc1bf5", size = 10274069 },
+    { url = "https://files.pythonhosted.org/packages/3d/12/0b3aa14d1d71546c988a28e1b412981c1b80c8a1072e977a2f30c595cc4a/ruff-0.8.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f05cdf8d050b30e2ba55c9b09330b51f9f97d36d4673213679b965d25a785f3c", size = 9909400 },
+    { url = "https://files.pythonhosted.org/packages/23/08/f9f08cefb7921784c891c4151cce6ed357ff49e84b84978440cffbc87408/ruff-0.8.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60f578c11feb1d3d257b2fb043ddb47501ab4816e7e221fbb0077f0d5d4e7b6f", size = 10766782 },
+    { url = "https://files.pythonhosted.org/packages/e4/71/bf50c321ec179aa420c8ec40adac5ae9cc408d4d37283a485b19a2331ceb/ruff-0.8.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cbd5cf9b0ae8f30eebc7b360171bd50f59ab29d39f06a670b3e4501a36ba5897", size = 10286316 },
+    { url = "https://files.pythonhosted.org/packages/f2/83/c82688a2a6117539aea0ce63fdf6c08e60fe0202779361223bcd7f40bd74/ruff-0.8.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b402ddee3d777683de60ff76da801fa7e5e8a71038f57ee53e903afbcefdaa58", size = 11338270 },
+    { url = "https://files.pythonhosted.org/packages/7f/d7/bc6a45e5a22e627640388e703160afb1d77c572b1d0fda8b4349f334fc66/ruff-0.8.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:705832cd7d85605cb7858d8a13d75993c8f3ef1397b0831289109e953d833d29", size = 12058579 },
+    { url = "https://files.pythonhosted.org/packages/da/3b/64150c93946ec851e6f1707ff586bb460ca671581380c919698d6a9267dc/ruff-0.8.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:32096b41aaf7a5cc095fa45b4167b890e4c8d3fd217603f3634c92a541de7248", size = 11615172 },
+    { url = "https://files.pythonhosted.org/packages/e4/9e/cf12b697ea83cfe92ec4509ae414dc4c9b38179cc681a497031f0d0d9a8e/ruff-0.8.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e769083da9439508833cfc7c23e351e1809e67f47c50248250ce1ac52c21fb93", size = 12882398 },
+    { url = "https://files.pythonhosted.org/packages/a9/27/96d10863accf76a9c97baceac30b0a52d917eb985a8ac058bd4636aeede0/ruff-0.8.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fe716592ae8a376c2673fdfc1f5c0c193a6d0411f90a496863c99cd9e2ae25d", size = 11176094 },
+    { url = "https://files.pythonhosted.org/packages/eb/10/cd2fd77d4a4e7f03c29351be0f53278a393186b540b99df68beb5304fddd/ruff-0.8.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:81c148825277e737493242b44c5388a300584d73d5774defa9245aaef55448b0", size = 10771884 },
+    { url = "https://files.pythonhosted.org/packages/71/5d/beabb2ff18870fc4add05fa3a69a4cb1b1d2d6f83f3cf3ae5ab0d52f455d/ruff-0.8.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d261d7850c8367704874847d95febc698a950bf061c9475d4a8b7689adc4f7fa", size = 10382535 },
+    { url = "https://files.pythonhosted.org/packages/ae/29/6b3fdf3ad3e35b28d87c25a9ff4c8222ad72485ab783936b2b267250d7a7/ruff-0.8.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1ca4e3a87496dc07d2427b7dd7ffa88a1e597c28dad65ae6433ecb9f2e4f022f", size = 10886995 },
+    { url = "https://files.pythonhosted.org/packages/e9/dc/859d889b4d9356a1a2cdbc1e4a0dda94052bc5b5300098647e51a58c430b/ruff-0.8.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:729850feed82ef2440aa27946ab39c18cb4a8889c1128a6d589ffa028ddcfc22", size = 11220750 },
+    { url = "https://files.pythonhosted.org/packages/0b/08/e8f519f61f1d624264bfd6b8829e4c5f31c3c61193bc3cff1f19dbe7626a/ruff-0.8.2-py3-none-win32.whl", hash = "sha256:ac42caaa0411d6a7d9594363294416e0e48fc1279e1b0e948391695db2b3d5b1", size = 8729396 },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/ba1c7ab72aba37a2b71fe48ab95b80546dbad7a7f35ea28cf66fc5cea5f6/ruff-0.8.2-py3-none-win_amd64.whl", hash = "sha256:2aae99ec70abf43372612a838d97bfe77d45146254568d94926e8ed5bbb409ea", size = 9594729 },
+    { url = "https://files.pythonhosted.org/packages/23/34/db20e12d3db11b8a2a8874258f0f6d96a9a4d631659d54575840557164c8/ruff-0.8.2-py3-none-win_arm64.whl", hash = "sha256:fb88e2a506b70cfbc2de6fae6681c4f944f7dd5f2fe87233a7233d888bad73e8", size = 9035131 },
 ]
 
 [[package]]
@@ -158,25 +153,5 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
     { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
     { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
-    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
-    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
-    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
-    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
-    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
-    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
-    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
-    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
-    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
-    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
-    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
-    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
-    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
-    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
-    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
-    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
-    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
-    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
-    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
-    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]


### PR DESCRIPTION
Update the required Python version to ">=3.10, <3.12" in the  `uv.lock` file to ensure compatibility with newer features and  improvements. Remove outdated wheel entries for `tomli` to  streamline the dependency list and reduce potential conflicts.